### PR TITLE
Avoid further visual quirks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "splittermond-tickleiste",
-	"version": "1.1.10",
+	"version": "1.1.11",
 	"description": "A Svelte-based application for managing initiative tracking in the pen&paper roleplaying game Splittermond.",
 	"type": "module",
 	"scripts": {

--- a/src/lib/components/CombatantEntry.svelte
+++ b/src/lib/components/CombatantEntry.svelte
@@ -118,7 +118,7 @@
 				<div class="min-w-12"></div>
 			</div>
 		</div>
-		<div class="mt-2 flex flex-row flex-wrap">
+		<div class="mt-2 flex flex-row flex-wrap" class:hidden={combatant.conditionStates.length === 0}>
 			{#each combatant.conditionStates as conditionState}
 				<button
 					class="badge badge-error badge-outline badge-lg mr-1 self-end"

--- a/src/lib/components/CombatantEntry.svelte
+++ b/src/lib/components/CombatantEntry.svelte
@@ -121,7 +121,7 @@
 		<div class="mt-2 flex flex-row flex-wrap" class:hidden={combatant.conditionStates.length === 0}>
 			{#each combatant.conditionStates as conditionState}
 				<button
-					class="badge badge-error badge-outline badge-lg mr-1 self-end"
+					class="badge badge-error badge-outline badge-lg mr-1 self-end hover:bg-error hover:text-neutral"
 					onclick={(event) => onBadgeClicked(combatant, conditionState, event)}
 				>
 					<span class="text-nowrap"

--- a/src/lib/components/modal/CombatantModal.svelte
+++ b/src/lib/components/modal/CombatantModal.svelte
@@ -87,7 +87,7 @@
 				{$_('combatant_modal.actions')}
 			</button>
 			<div
-				class="tab-content border-r-0 border-none bg-base-100 p-6"
+				class="tab-content min-w-full border-r-0 border-none bg-base-100 p-6"
 				id="tabpanel-tick-selection"
 				role="tabpanel"
 				tabindex="0"

--- a/src/lib/components/modal/TickSelection.svelte
+++ b/src/lib/components/modal/TickSelection.svelte
@@ -123,7 +123,7 @@
 			>
 				<button
 					class="btn h-full w-full"
-					class:btn-active={negation}
+					class:btn-primary={negation}
 					onclick={() => toggleNegation()}
 					aria-label={$_('tickselection.tooltip.tick_direction', {
 						values: { n: Number(negation) }

--- a/src/lib/utility/html_details_element_extension.ts
+++ b/src/lib/utility/html_details_element_extension.ts
@@ -11,8 +11,10 @@ export function addToggleListener(details: HTMLDetailsElement) {
 	details.addEventListener('toggle', () => {
 		if (details.open) {
 			addListenersForDetailsElement(details);
+			details.querySelector('summary')?.classList.add('btn-active');
 		} else {
 			destroyListenersForDetailsElement(details);
+			details.querySelector('summary')?.classList.remove('btn-active');
 		}
 	});
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -25,7 +25,7 @@ const splitter_light = {
 	'neutral-content': '#d0d1d0',
 	'base-100': '#c5dbe0',
 	'base-200': '#85837c',
-	'base-300': '#141918',
+	'base-300': '#696969',
 	'base-content': '#141918',
 	...complementary_colors
 };
@@ -39,7 +39,7 @@ const splitter_dark = {
 	'neutral-content': '#d0d1d0',
 	'base-100': '#1f2624',
 	'base-200': '#444440',
-	'base-300': '#141918',
+	'base-300': '#383834',
 	'base-content': '#C7E7F1',
 	...complementary_colors
 };


### PR DESCRIPTION
- full width for tick selection on phones
- badges visual feedback on hover
- avoid additional slide animation when switchting between editing-running mode by hiding invisible condition badge container element, when none are given
- button style change on tick negation for better visual feedback
- adjust theme colors to ensure neutral btn style stays readable
- when menu in header is open, then add active style to button