### PR TITLE
Streamline language handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "splittermond-tickleiste",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"description": "A Svelte-based application for managing initiative tracking in the pen&paper roleplaying game Splittermond.",
 	"type": "module",
 	"scripts": {

--- a/src/app.html
+++ b/src/app.html
@@ -6,15 +6,15 @@
 		<link rel="icon" type="image/png" sizes="32x32" href="%sveltekit.assets%/favicon-32x32.png" />
 		<link rel="icon" type="image/png" sizes="16x16" href="%sveltekit.assets%/favicon-16x16.png" />
 		<link rel="manifest" href="%sveltekit.assets%/site.webmanifest" />
-		<title>Splittermond Tickbar</title>
-		<meta property="og:title" content="Splittermond Tickbar" />
+		<title>Splittermond Tickleiste</title>
+		<meta property="og:title" content="Splittermond Tickleiste" />
 		<meta
 			name="description"
-			content="Web app for managing the tickbar system of the splittermond pen and paper roleplaying game."
+			content="Web-Applikation zur Verwaltung des Tickleisten-Systems des Splittermond Pen-and-Paper-Rollenspiels."
 		/>
 		<meta
 			property="og:description"
-			content="Web app for managing the tickbar system of the splittermond pen and paper roleplaying game."
+			content="Web-Applikation zur Verwaltung des Tickleisten-Systems des Splittermond Pen-and-Paper-Rollenspiels."
 		/>
 		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 		<meta property="og:image" content="%sveltekit.assets%/favicon-32x32.png" />

--- a/src/app.html
+++ b/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html data-theme="splitter_dark" lang="en">
+<html data-theme="splitter_dark" lang="de">
 	<head>
 		<meta charset="utf-8" />
 		<link rel="apple-touch-icon" sizes="180x180" href="%sveltekit.assets%/apple-touch-icon.png" />

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,12 +1,17 @@
-import { addMessages, getLocaleFromNavigator, init } from 'svelte-i18n';
-
+import { addMessages, init } from 'svelte-i18n';
 import en from './locales/en.json';
 import de from './locales/de.json';
+import { loadAttribute } from '$lib/state/localstorage';
+import { KEY_LOCALE, DEFAULT_LOCALE, Locale } from '$lib/utility/locale';
 
-addMessages('en', en);
-addMessages('de', de);
+addMessages(Locale.German, de);
+addMessages(Locale.English, en);
 
-init({
-	fallbackLocale: 'en',
-	initialLocale: getLocaleFromNavigator()
-});
+export async function initI18n() {
+	return await Promise.allSettled([
+		init({
+			fallbackLocale: Locale.German,
+			initialLocale: loadAttribute<string>(KEY_LOCALE) || DEFAULT_LOCALE
+		})
+	]);
+}

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -2,37 +2,23 @@
 	import { X } from 'lucide-svelte';
 	import { base } from '$app/paths';
 	import { loadAttribute, saveAttribute } from '$lib/state/localstorage';
-	import { onMount } from 'svelte';
 	let dataPrivacyModal: HTMLDialogElement;
 	import { _, locale } from 'svelte-i18n';
+	import { DEFAULT_LOCALE, KEY_LOCALE, Locale } from '$lib/utility/locale';
 
 	// eslint-disable-next-line no-undef
 	const APP_NAME = __APP_NAME__;
 	// eslint-disable-next-line no-undef
 	const APP_VERSION = __APP_VERSION__;
 
-	const Locale = {
-		German: 'de',
-		English: 'en'
-	};
-	const KEY_LOCALE: string = 'locale';
-	const DEFAULT_LOCALE: string = Locale.German;
-	let selected_locale: string = $state(DEFAULT_LOCALE);
+	let selected_locale: string = $state(loadAttribute<string>(KEY_LOCALE) || DEFAULT_LOCALE);
 	let isModalOpen: boolean = $state(false);
-
-	onMount(() => {
-		const locale = loadAttribute<string>(KEY_LOCALE);
-		selected_locale = locale || DEFAULT_LOCALE;
-	});
-
-	$effect(() => {
-		$locale = selected_locale || DEFAULT_LOCALE;
-	});
 
 	function toggleLanguage() {
 		selected_locale = selected_locale === Locale.German ? Locale.English : Locale.German;
 		saveAttribute(KEY_LOCALE, selected_locale);
-		document.title = $_('app_title', { locale: selected_locale });
+		$locale = selected_locale;
+		document.title = $_('app_title');
 	}
 
 	function openDataPrivacy() {
@@ -53,12 +39,16 @@
 	<button onclick={openDataPrivacy}>{$_('data_privacy')}</button>
 	<button id="ToggleLanguageBtn" onclick={() => toggleLanguage()}>
 		{#if $locale === 'en'}
-			<img width="30em" src="{base}/svg/flag-for-flag-germany-svgrepo-com.svg" alt="German" />
+			<img
+				width="30em"
+				src="{base}/svg/flag-for-flag-germany-svgrepo-com.svg"
+				alt="Sprache auf Deutsch stellen"
+			/>
 		{:else}
 			<img
 				width="30em"
 				src="{base}/svg/flag-for-flag-united-kingdom-svgrepo-com.svg"
-				alt="English"
+				alt="Set language to English"
 			/>
 		{/if}
 	</button>

--- a/src/lib/state/localstorage.ts
+++ b/src/lib/state/localstorage.ts
@@ -25,7 +25,7 @@ export const removeAttribute = (key: string) => {
 
 export const saveSceneToLocalStorage = (scene: Scene) => {
 	localStorage.setItem('scene', JSON.stringify(scene));
-	console.info('Data saved to localStorage');
+	console.info('Scene saved to localStorage');
 };
 
 export const loadSceneFromLocalStorage = (): Scene | null => {

--- a/src/lib/utility/locale.ts
+++ b/src/lib/utility/locale.ts
@@ -1,0 +1,7 @@
+export const Locale = {
+	German: 'de',
+	English: 'en'
+};
+
+export const KEY_LOCALE: string = 'locale';
+export const DEFAULT_LOCALE: string = Locale.German;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,3 +1,13 @@
+<script module>
+	import { DEFAULT_LOCALE } from '$lib/utility/locale';
+	import { waitLocale } from 'svelte-i18n';
+
+	export async function preload() {
+		// awaits for the loading of the default locale ('de') dictionary
+		return waitLocale(DEFAULT_LOCALE);
+	}
+</script>
+
 <script lang="ts">
 	import '../app.css';
 	let { children } = $props();

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,12 +1,1 @@
-import { browser } from '$app/environment';
-import { locale, waitLocale } from 'svelte-i18n';
-import type { LayoutLoad } from './$types';
-
 export const prerender = true;
-
-export const load: LayoutLoad = async () => {
-	if (browser) {
-		locale.set(window.navigator.language);
-	}
-	await waitLocale();
-};

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,15 +5,15 @@
 	import { loadSceneFromLocalStorage } from '$lib/state/localstorage';
 	import Scene from '$lib/components/Scene.svelte';
 	import Footer from '$lib/components/Footer.svelte';
-	import '../i18n';
+	import { initI18n } from '../i18n';
 	import { _ } from 'svelte-i18n';
 	import { base } from '$app/paths';
 	import { fade } from 'svelte/transition';
 
 	let loading = $state(true);
 
-	onMount(() => {
-		// ensure that title of HTML is set in correct language
+	onMount(async () => {
+		await initI18n();
 
 		const _scene = loadSceneFromLocalStorage();
 		if (_scene) {
@@ -21,6 +21,8 @@
 		}
 		// hide loading state after everything has been initialized
 		loading = false;
+		// ensure that title of HTML is set in correct language
+		document.title = $_('app_title');
 	});
 
 	$inspect(sceneData);
@@ -39,7 +41,6 @@
 		>
 			<img class="max-h-20" src="{base}/logo.png" alt="splittermond logo" />
 			<span class="loading loading-ring loading-lg my-8 text-primary"></span>
-			<p class="sr-only">{$_('loading_scene')}</p>
 		</div>
 	{:else}
 		<div in:fade={{ delay: 200 }} class="flex min-h-screen flex-col">


### PR DESCRIPTION
- put german as default everywhere (was mixed between english and german before)
- reduce amount of places where language is set on initial load
- prefer language from localStorage before navigator language