### PR TITLE
Fix loading race conditions bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "splittermond-tickleiste",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"description": "A Svelte-based application for managing initiative tracking in the pen&paper roleplaying game Splittermond.",
 	"type": "module",
 	"scripts": {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,13 +1,3 @@
-<script module>
-	import { DEFAULT_LOCALE } from '$lib/utility/locale';
-	import { waitLocale } from 'svelte-i18n';
-
-	export async function preload() {
-		// awaits for the loading of the default locale ('de') dictionary
-		return waitLocale(DEFAULT_LOCALE);
-	}
-</script>
-
 <script lang="ts">
 	import '../app.css';
 	let { children } = $props();

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,1 +1,8 @@
+import { DEFAULT_LOCALE } from '$lib/utility/locale';
+import { waitLocale } from 'svelte-i18n';
 export const prerender = true;
+import type { LayoutLoad } from './$types';
+
+export const load: LayoutLoad = async () => {
+	await waitLocale(DEFAULT_LOCALE);
+};

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -28,7 +28,7 @@
 	$inspect(sceneData);
 
 	$effect(() => {
-		saveScene();
+		if (!loading) saveScene();
 	});
 </script>
 


### PR DESCRIPTION
Because of the recently introduced async loading of the i18n dictionaries, we introduced a race condition. It saved an empty state to the localStorage before it was able to load an existing scene from it. 

To avoid this, I use the loading flag to ensure that during the loading of all files, nothing gets saved into the localStorage. 