### PR TITLE
Make more use of space on mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "splittermond-tickleiste",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"description": "A Svelte-based application for managing initiative tracking in the pen&paper roleplaying game Splittermond.",
 	"type": "module",
 	"scripts": {

--- a/src/lib/components/CombatantEntry.svelte
+++ b/src/lib/components/CombatantEntry.svelte
@@ -58,10 +58,13 @@
 </script>
 
 {#if appMode === 'RUNNING'}
-	<div class="p-6">
-		<div class="grid w-full grid-cols-[98fr_1fr_1fr] gap-2">
+	<div class="p-3 md:p-6">
+		<div class="flex w-full items-center justify-between">
 			<div class="relative">
-				<p aria-label={$_('combatant_name')} class="my-auto w-full ps-4 text-left text-3xl">
+				<p
+					aria-label={$_('combatant_name')}
+					class="my-auto w-full ps-4 text-left text-2xl md:text-3xl"
+				>
 					{combatant.name}
 				</p>
 				{#if combatant === nextActingCombatant}
@@ -73,11 +76,11 @@
 					</div>
 				{/if}
 			</div>
-			<div class="self-start">
+			<div class="mx-2 mr-16 self-start">
 				{#if combatant.combatState === 'Active'}
 					<button
 						aria-label={$_('combatant_initiative')}
-						class="btn btn-primary w-20 px-1 text-center text-3xl"
+						class="btn btn-primary w-16 px-1 text-center text-2xl md:w-20 md:text-3xl"
 						onclick={() => combatantClicked(combatant)}
 					>
 						{combatant.initiative}
@@ -86,10 +89,10 @@
 				{:else if combatant.combatState === 'Waiting'}
 					<button
 						in:fade={{ duration: 200 }}
-						class="btn btn-warning w-20 px-1 text-center"
+						class="btn btn-warning w-16 px-1 text-center md:w-20"
 						onclick={() => combatantClicked(combatant)}
 					>
-						<Hourglass class="w-20 text-center" size={32} strokeWidth={2} />
+						<Hourglass class="w-16 text-center md:w-20" size={32} strokeWidth={2} />
 						<span class="sr-only"
 							>{$_('combatant_status', {
 								values: { status: $_('tickselection.tooltip.set_state_waiting') }
@@ -100,7 +103,7 @@
 				{:else if combatant.combatState === 'Expecting'}
 					<button
 						in:fade={{ duration: 200 }}
-						class="btn btn-warning w-20 px-1 text-center"
+						class="btn btn-warning w-16 px-1 text-center md:w-20"
 						onclick={() => combatantClicked(combatant)}
 					>
 						<ClockAlert class="w-20 text-center" size={32} strokeWidth={2} />
@@ -114,7 +117,7 @@
 				{:else if combatant.combatState === 'Dead'}
 					<button
 						in:fade={{ duration: 200 }}
-						class="btn btn-error w-20 px-1 text-center"
+						class="px btn btn-error w-16 text-center md:w-20"
 						onclick={() => combatantClicked(combatant)}
 					>
 						<Skull class="w-20 text-center" size={32} strokeWidth={2} />
@@ -127,11 +130,8 @@
 					</button>
 				{/if}
 			</div>
-			<div class="w-16 text-center">
-				<div class="min-w-12"></div>
-			</div>
 		</div>
-		<div class="mt-2 flex flex-row flex-wrap" class:hidden={combatant.conditionStates.length === 0}>
+		<div class="mt-1 flex flex-row flex-wrap" class:hidden={combatant.conditionStates.length === 0}>
 			{#each combatant.conditionStates as conditionState}
 				<button
 					class="badge badge-error badge-outline badge-lg mr-1 self-end hover:bg-error hover:text-neutral"
@@ -151,37 +151,29 @@
 {/if}
 
 {#if appMode === 'EDITING'}
-	<div class="p-6">
-		<div class="grid w-full grid-cols-[98fr_1fr_1fr] items-center gap-2">
-			<div class="relative">
-				<div class="flex flex-col">
-					<input
-						type="text"
-						aria-label={$_('combatant_name')}
-						class="input input-bordered my-auto w-full text-3xl"
-						bind:value={combatant.name}
-					/>
-				</div>
-			</div>
-			<div>
-				<input
-					type="number"
-					aria-label={$_('combatant_initiative')}
-					class="input input-bordered w-20 px-1 text-center text-3xl"
-					onfocus={(event: FocusEvent) => selectInputText(event)}
-					bind:value={combatant.initiative}
-				/>
-			</div>
-			<div class="w-16 text-center">
-				<button
-					in:fade={{ duration: 200 }}
-					class="btn btn-error w-full"
-					onclick={() => deleteCombatant(combatant.id)}
-					aria-label={$_('delete_combatant', { values: { name: combatant.name } })}
-				>
-					<Trash aria-hidden />
-				</button>
-			</div>
+	<div class="p-3 md:p-6">
+		<div class="flex w-full items-center">
+			<input
+				type="text"
+				aria-label={$_('combatant_name')}
+				class="input input-bordered my-auto w-full text-2xl md:text-3xl"
+				bind:value={combatant.name}
+			/>
+			<input
+				type="number"
+				aria-label={$_('combatant_initiative')}
+				class="input input-bordered mx-2 w-16 px-1 text-center text-2xl md:w-20 md:text-3xl"
+				onfocus={(event: FocusEvent) => selectInputText(event)}
+				bind:value={combatant.initiative}
+			/>
+			<button
+				in:fade={{ duration: 200 }}
+				class="btn btn-error"
+				onclick={() => deleteCombatant(combatant.id)}
+				aria-label={$_('delete_combatant', { values: { name: combatant.name } })}
+			>
+				<Trash aria-hidden />
+			</button>
 		</div>
 	</div>
 {/if}

--- a/src/lib/components/Scene.svelte
+++ b/src/lib/components/Scene.svelte
@@ -107,11 +107,11 @@
 				<input
 					type="text"
 					placeholder={$_('scene_title')}
-					class="input input-bordered mr-4 w-full text-2xl md:text-3xl"
+					class="input input-bordered mr-2 w-full text-2xl md:text-3xl"
 					bind:value={sceneData.name}
 				/>
 			{:else}
-				<p class="mr-4 w-full ps-[17px] text-2xl md:text-3xl" aria-label={$_('scene_title')}>
+				<p class="mr-2 w-full ps-[17px] text-2xl md:text-3xl" aria-label={$_('scene_title')}>
 					{sceneData.name}
 				</p>
 			{/if}
@@ -120,7 +120,7 @@
 		<div class="change-scene-mode flex-none space-x-2">
 			<button
 				id="runSceneBtn"
-				class="btn btn-primary"
+				class="btn btn-primary text-xl"
 				class:hidden={appMode == 'RUNNING'}
 				disabled={sceneData.combatants.length === 0}
 				onclick={runScene}

--- a/src/lib/components/Scene.svelte
+++ b/src/lib/components/Scene.svelte
@@ -107,11 +107,11 @@
 				<input
 					type="text"
 					placeholder={$_('scene_title')}
-					class="input input-bordered mr-4 w-full text-3xl"
+					class="input input-bordered mr-4 w-full text-2xl md:text-3xl"
 					bind:value={sceneData.name}
 				/>
 			{:else}
-				<p class="mr-4 w-full ps-[17px] text-3xl" aria-label={$_('scene_title')}>
+				<p class="mr-4 w-full ps-[17px] text-2xl md:text-3xl" aria-label={$_('scene_title')}>
 					{sceneData.name}
 				</p>
 			{/if}
@@ -120,7 +120,7 @@
 		<div class="change-scene-mode flex-none space-x-2">
 			<button
 				id="runSceneBtn"
-				class="btn btn-primary text-xl"
+				class="btn btn-primary"
 				class:hidden={appMode == 'RUNNING'}
 				disabled={sceneData.combatants.length === 0}
 				onclick={runScene}
@@ -141,18 +141,20 @@
 	</div>
 	<div id="combatantsTable" class="mb-2 mt-4">
 		<!-- Table Header -->
-		<div class="grid grid-cols-[99fr_1fr_1fr] gap-x-2 rounded-lg bg-secondary px-6 pb-4 pt-3">
-			<div class="text-xl font-bold">{$_('column_name')}</div>
-			<div class="text-xl font-bold" id="initiativeColumn">{$_('column_initiative')}</div>
-			<div class="w-16"></div>
-
+		<div class="column rounded-lg bg-secondary p-3 md:p-6">
+			<div class="flex w-full justify-between">
+				<div class="pl-1 text-xl">{$_('column_name')}</div>
+				<div class="mr-16 w-16 pl-1 text-xl md:w-20" id="initiativeColumn">
+					{$_('column_initiative')}
+				</div>
+			</div>
 			<!-- Combatant Input Fields -->
 			{#if appMode === 'EDITING'}
-				<div transition:slide class="col-span-3 mt-2 grid grid-cols-subgrid">
+				<div transition:slide class="col-span-3 flex w-full">
 					<input
 						type="text"
 						placeholder={$_('placeholder_name')}
-						class="input input-bordered w-full text-3xl"
+						class="input input-bordered w-full text-2xl md:text-3xl"
 						bind:value={newCombatant.name}
 						bind:this={combatantNameInput}
 						onkeydown={handleKeyDown}
@@ -161,20 +163,23 @@
 						type="number"
 						placeholder={$_('placeholder_initiative')}
 						class="
-								input
-								input-bordered
-								w-20
-								px-1
-								text-center
-								text-3xl"
+						input
+						input-bordered
+						mx-1.5
+						w-16
+						px-1
+						text-center
+						text-2xl
+						md:w-20
+						md:text-3xl"
 						bind:value={newCombatant.initiative}
 						onfocus={(event: FocusEvent) => selectInputText(event)}
 						onkeydown={handleKeyDown}
 					/>
-					<div class="w-16 justify-center">
+					<div class="justify-center">
 						<button
 							onclick={() => addCombatant(newCombatant)}
-							class="btn btn-primary w-full"
+							class="btn btn-primary"
 							aria-label={$_('add_combatant')}
 						>
 							<Plus strokeWidth={3} aria-hidden />
@@ -184,11 +189,9 @@
 			{/if}
 		</div>
 
-		<!-- <div class="my-2"></div> -->
-
 		<!-- Combatant List -->
 		{#if sceneData.combatants.length === 0}
-			<div class=" card mt-8 bg-base-100">
+			<div class="card mt-8 bg-base-100">
 				<div class="card-body text-center">
 					<h2 class="card-title justify-center">{$_('scene.empty_combatants_info')}</h2>
 					<p class="mt-6">

--- a/src/lib/components/combatant_modal/CombatantModal.svelte
+++ b/src/lib/components/combatant_modal/CombatantModal.svelte
@@ -74,7 +74,11 @@
 		<h3 id="tablist-for-combatant" class="sr-only">
 			{$_('combatant_interaction_modal', { values: { name: sessionData.activeCombatant?.name } })}
 		</h3>
-		<div role="tablist" class="tabs-boxed tabs p-0" aria-labelledby="tablist-for-combatant">
+		<div
+			role="tablist"
+			class="tabs-boxed tabs overflow-hidden p-0"
+			aria-labelledby="tablist-for-combatant"
+		>
 			<button
 				bind:this={tabButtonTicks}
 				role="tab"

--- a/src/lib/components/combatant_modal/CombatantModal.svelte
+++ b/src/lib/components/combatant_modal/CombatantModal.svelte
@@ -79,7 +79,7 @@
 				bind:this={tabButtonTicks}
 				role="tab"
 				id="tab-tick-selection"
-				class="tab m-2 me-1 h-12 text-2xl"
+				class="tab m-2 me-1 h-12 text-xl"
 				aria-controls="tabpanel-tick-selection"
 				aria-selected="true"
 				class:tab-active={tabButtonTicks?.ariaSelected === 'actions'}
@@ -87,7 +87,7 @@
 				{$_('combatant_modal.actions')}
 			</button>
 			<div
-				class="tab-content min-w-full border-r-0 border-none bg-base-100 p-6"
+				class="tab-content min-w-full border-r-0 border-none bg-base-100 p-3 md:p-6"
 				id="tabpanel-tick-selection"
 				role="tabpanel"
 				tabindex="0"
@@ -99,7 +99,7 @@
 				bind:this={tabButtonConditions}
 				role="tab"
 				id="tab-condition-selection"
-				class="tab m-2 me-1 ms-0 h-12 text-2xl"
+				class="tab m-2 me-1 ms-0 h-12 text-xl"
 				tabindex="-1"
 				aria-controls="tabpanel-condition-selection"
 				aria-selected="false"
@@ -108,7 +108,7 @@
 				{$_('combatant_modal.conditions')}
 			</button>
 			<div
-				class="tab-content min-w-full border-r-0 border-none bg-base-100 p-6"
+				class="tab-content min-w-full border-r-0 border-none bg-base-100 p-3 md:p-6"
 				id="tabpanel-condition-selection"
 				role="tabpanel"
 				tabindex="0"

--- a/src/lib/components/combatant_modal/ConditionSelection.svelte
+++ b/src/lib/components/combatant_modal/ConditionSelection.svelte
@@ -78,22 +78,24 @@
 	}
 </script>
 
-<div class="grid grid-cols-2 gap-4">
+<div class="grid grid-cols-2 gap-2 md:gap-4">
 	{#each getSortedConditions(getAllConditions({ onlyActive: true })) as condition}
 		<button
 			class:btn-outline={!isActiveOnActiveCombatant(condition.id)}
 			class:btn-error={isActiveOnActiveCombatant(condition.id)}
-			class="btn md:text-xl"
+			class="btn px-2 text-lg font-normal md:text-xl"
 			onclick={() => select(condition.id)}
 		>
-			<span class="text-nowrap">
+			<span class="leading-none">
 				{$_(condition.i18n)}{resolveCurrentLevel(condition.id)}
 				{#if isActiveOnActiveCombatant(condition.id)}
-					(<Timer
-						class="mb-1 inline-block align-middle"
-						size={16}
-						strokeWidth={2}
-					/>&nbsp;{calculateConditionDuration(condition.id)})
+					<span class="text-nowrap">
+						(<Timer
+							class="mb-1 inline-block align-middle"
+							size={16}
+							strokeWidth={2}
+						/>&nbsp;{calculateConditionDuration(condition.id)})
+					</span>
 				{:else}
 					<span class="text-sm"
 						>{resolveLevelRange(condition.id, getSortedConditions(getAllConditions()))}</span

--- a/src/lib/components/combatant_modal/TickSelection.svelte
+++ b/src/lib/components/combatant_modal/TickSelection.svelte
@@ -85,7 +85,7 @@
 	}
 </script>
 
-<div class="grid grid-cols-4 gap-1 md:grid-cols-5">
+<div class="grid grid-cols-4 gap-2 md:grid-cols-5">
 	{#each sessionData.ticks as tick}
 		<button
 			class="tick-selection btn relative aspect-square h-full w-full min-[320px]:text-2xl sm:text-3xl"
@@ -114,7 +114,7 @@
 		</button>
 	{/each}
 </div>
-<div class="mt-1 grid grid-cols-4 gap-1 md:grid-cols-5">
+<div class="mt-2 grid grid-cols-4 gap-2 md:grid-cols-5">
 	<div>
 		{#if sessionData.activeCombatant === null || sessionData.activeCombatant?.combatState === 'Active'}
 			<div

--- a/src/lib/components/combatant_modal/TickSelection.svelte
+++ b/src/lib/components/combatant_modal/TickSelection.svelte
@@ -85,7 +85,7 @@
 	}
 </script>
 
-<div class="grid grid-cols-4 gap-2 md:grid-cols-5">
+<div class="grid grid-cols-4 gap-1 md:grid-cols-5">
 	{#each sessionData.ticks as tick}
 		<button
 			class="tick-selection btn relative aspect-square h-full w-full min-[320px]:text-2xl sm:text-3xl"
@@ -114,7 +114,7 @@
 		</button>
 	{/each}
 </div>
-<div class="mt-2 grid grid-cols-4 gap-2 md:grid-cols-5">
+<div class="mt-2 grid grid-cols-4 gap-1 md:grid-cols-5">
 	<div>
 		{#if sessionData.activeCombatant === null || sessionData.activeCombatant?.combatState === 'Active'}
 			<div

--- a/src/lib/components/settings/SettingsModal.svelte
+++ b/src/lib/components/settings/SettingsModal.svelte
@@ -72,11 +72,11 @@
 				bind:value={customConditionName}
 				name="custom_condition_name"
 				placeholder="{$_('settings.custom_condition_placeholder')} "
-				class="input input-bordered mr-4 w-full text-xl md:text-2xl"
+				class="input input-bordered mr-2 w-full text-xl md:mr-4 md:text-2xl"
 				aria-label={$_('settings.new_condition_name')}
 			/>
 			<select
-				class="select select-bordered mr-4 text-center text-xl md:text-2xl"
+				class="select select-bordered mr-2 text-center text-xl md:mr-4 md:text-2xl"
 				name="custom_condition_max_level"
 				bind:value={customConditionMaxLevel}
 				aria-label={$_('settings.new_condition_level')}


### PR DESCRIPTION
Problem: When names of combatants or conditions are getting a bit longer, the view gets really cramped or even breaks. 

Solution: Reduce font-sizes and spacings for mobile to support longer namings.

| before | after |
|---|---|
| <img src="https://github.com/user-attachments/assets/a46ec5c8-b8c5-4b85-8a49-b18df166e87e" width="250"/> | <img src="https://github.com/user-attachments/assets/9311526d-bbbd-41ad-9d42-43bf39b7496a" width="250"/> |
| <img src="https://github.com/user-attachments/assets/c6789641-c61e-4481-ad54-8b3bcae7518c" width="250"/> |  <img src="https://github.com/user-attachments/assets/c3364f63-ed60-4af7-b22f-c37a8a387275" width="250"/> |
| <img src="https://github.com/user-attachments/assets/01763173-fbf7-4248-9724-b9a94385c609" width="250"/> |  <img src="https://github.com/user-attachments/assets/b1badd78-71a0-464d-8058-e14b52e8ae99" width="250"/> |
|  <img src="https://github.com/user-attachments/assets/5f3fcd58-4dc0-4579-a8f4-9f6b42afdd51" width="250"/> | <img src="https://github.com/user-attachments/assets/b93e45fc-ce93-4b33-b8e5-bb6c5ca86467" width="250" /> |

